### PR TITLE
adding middleware to check if instance is alive

### DIFF
--- a/services/administration/k8s/pgrest/base/deployment.yaml
+++ b/services/administration/k8s/pgrest/base/deployment.yaml
@@ -6,7 +6,6 @@ spec:
   selector:
     matchLabels:
       app:  
-  replicas: 1
   template:
     metadata:
       labels:

--- a/services/administration/k8s/postgres/base/statefulset.yaml
+++ b/services/administration/k8s/postgres/base/statefulset.yaml
@@ -6,7 +6,6 @@ spec:
   selector:
     matchLabels:
       app:  
-  replicas: 1
   serviceName: 
   template:
     metadata:

--- a/services/administration/src/controllers/api/database.js
+++ b/services/administration/src/controllers/api/database.js
@@ -3,6 +3,7 @@ import {database, pgRest, instance, user, organization, admin} from '../../../..
 import keycloak from '../../../../lib/keycloak.js';
 import handleError from '../handle-errors.js';
 import {middleware as contextMiddleware} from '../../../../lib/context.js';
+import isInstanceAlive from '../middleware/instance-alive.js';
 
 const router = Router();
 
@@ -162,6 +163,7 @@ async function getFeatured(res){
 /** Get **/
 router.get('/:organization/:database',
   contextMiddleware,
+  isInstanceAlive({useAliveFlag: true}),
   async (req, res) => {
   try {
     let {organization, database, instance} = req.context;
@@ -242,6 +244,7 @@ router.post('/:organization/:database/api/restart',
 router.post('/:organization/:database/api/updated',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     await pgRest.updateApiSchemaCache(req.context);
@@ -254,6 +257,7 @@ router.post('/:organization/:database/api/updated',
 router.post('/:organization/:database/api/expose/:table',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     await pgRest.exposeTable(req.context, req.params.table);
@@ -268,6 +272,7 @@ router.post('/:organization/:database/api/expose/:table',
 router.post('/:organization/:database/init',
   contextMiddleware,
   keycloak.protect('admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     await instance.initInstanceDb(req.context);
@@ -305,6 +310,7 @@ router.get('/:organization/:database/users',
 router.get('/:organization/:database/schemas',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.listSchema(req.context));
@@ -316,6 +322,7 @@ router.get('/:organization/:database/schemas',
 router.get('/:organization/:database/users-overview',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.getUserAccessOverview(req.context));
@@ -328,6 +335,7 @@ router.get('/:organization/:database/users-overview',
 router.get('/:organization/:database/tables-overview',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.getTableAccessOverview(req.context));
@@ -339,6 +347,7 @@ router.get('/:organization/:database/tables-overview',
 router.get('/:organization/:database/schema/:schema/tables',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.listTables(
@@ -353,6 +362,7 @@ router.get('/:organization/:database/schema/:schema/tables',
 router.get('/:organization/:database/schema/:schema/tables-overview',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.getTableAccessOverview(
@@ -368,6 +378,7 @@ router.get('/:organization/:database/schema/:schema/tables-overview',
 router.get('/:organization/:database/schema/:schema/table/:tableName/access',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.getTableAccess(
@@ -383,6 +394,7 @@ router.get('/:organization/:database/schema/:schema/table/:tableName/access',
 router.get('/:organization/:database/schemas-overview',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     let result = await database.getSchemasOverview(
@@ -398,6 +410,7 @@ router.get('/:organization/:database/schemas-overview',
 router.get('/:organization/:database/schema/:schema/access/:username',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     res.json(await database.getTableAccessByUser(
@@ -414,6 +427,7 @@ router.get('/:organization/:database/schema/:schema/access/:username',
 router.put('/:organization/:database/grant/:schema/:user/:permission',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -442,6 +456,7 @@ router.put('/:organization/:database/grant/:schema/:user/:permission',
 router.post('/:organization/:database/grant',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -474,6 +489,7 @@ router.post('/:organization/:database/grant',
 router.delete('/:organization/:database/revoke/:schema/:user/:permission',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -502,6 +518,7 @@ router.delete('/:organization/:database/revoke/:schema/:user/:permission',
 router.post('/:organization/:database/revoke',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -533,6 +550,7 @@ router.post('/:organization/:database/revoke',
 /** Create foreign data table to PG Farm db **/
 router.post('/:organization/:database/link/:remoteOrg/:remoteDb',
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {

--- a/services/administration/src/controllers/api/instance.js
+++ b/services/administration/src/controllers/api/instance.js
@@ -5,6 +5,7 @@ import client from '../../../../lib/pg-admin-client.js';
 import handleError from '../handle-errors.js';
 import remoteExec from '../../../../lib/pg-helper-remote-exec.js';
 import {middleware as contextMiddleware} from '../../../../lib/context.js';
+import isInstanceAlive from '../middleware/instance-alive.js';
 
 const router = Router();
 
@@ -20,6 +21,7 @@ router.get('/', async (req, res) => {
 router.get('/:organization/:instance',
   contextMiddleware,
   keycloak.protect('instance-user'),
+  isInstanceAlive({useAliveFlag: true}),
   async (req, res) => {
   try {
     let resp = req.context.instance;
@@ -53,6 +55,7 @@ router.post('/',
 router.put('/:organization/:instance/:user',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -96,6 +99,7 @@ router.patch('/:organization/:instance/:user',
 router.delete('/:organization/:instance/:user',
   contextMiddleware,
   keycloak.protect('instance-admin'),
+  isInstanceAlive(),
   async (req, res) => {
 
   try {
@@ -158,6 +162,7 @@ router.post('/:organization/:instance/restart',
 router.post('/:organization/:instance/backup',
   contextMiddleware,
   keycloak.protect('admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     let resp = await remoteExec(req.context.instance.hostname, '/backup');
@@ -171,6 +176,7 @@ router.post('/:organization/:instance/backup',
 router.post('/:organization/:instance/sync-users',
   contextMiddleware,
   keycloak.protect('admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
 
@@ -196,6 +202,7 @@ router.post('/:organization/:instance/sync-users',
 router.post('/:organization/:instance/archive',
   contextMiddleware,
   keycloak.protect('admin'),
+  isInstanceAlive(),
   async (req, res) => {
   try {
     let {instance, organization} = req.context;

--- a/services/administration/src/controllers/middleware/instance-alive.js
+++ b/services/administration/src/controllers/middleware/instance-alive.js
@@ -1,0 +1,36 @@
+import utils from '../../../../lib/utils.js';
+import logger from '../../../../lib/logger.js';
+
+/**
+ * Middleware that checks if a given instance is alive by attempting to connect to its host and port.
+ * If the instance is not alive, it responds with a 503 status code.
+ */
+
+function createMiddleware(opts={}) {
+  async function isInstanceAlive(req, res, next) {
+    if( opts.useAliveFlag === true && req.query.isAlive !== 'true' ) {
+      return next();
+    }
+
+    if( !req.context ) {
+      logger.error('No context found in request', req.logSignal);
+      return res.status(500).json({error: 'No context found in request'});
+    }
+    if( !req.context.instance ) {
+      logger.error('No instance found in request context', req.logSignal);
+      return res.status(500).json({error: 'No instance found in request context'});
+    }
+
+    let instance = req.context.instance;
+
+    try {
+      await utils.isAlive(instance.host, instance.port, 2000);
+      return next();
+    } catch(e) {
+      return res.status(503).json({error: 'Instance is not alive', details: e.message});
+    }
+  }
+
+  return isInstanceAlive;
+}
+export default createMiddleware;

--- a/services/administration/src/controllers/middleware/instance-alive.js
+++ b/services/administration/src/controllers/middleware/instance-alive.js
@@ -1,5 +1,6 @@
 import utils from '../../../../lib/utils.js';
 import logger from '../../../../lib/logger.js';
+import instanceModel from '../../../../models/instance.js'
 
 /**
  * Middleware that checks if a given instance is alive by attempting to connect to its host and port.
@@ -27,7 +28,14 @@ function createMiddleware(opts={}) {
       await utils.isAlive(instance.host, instance.port, 2000);
       return next();
     } catch(e) {
-      return res.status(503).json({error: 'Instance is not alive', details: e.message});
+      return res.status(503).json({
+        error: 'Instance is not responsive', 
+        details: e.message,
+        organization: ctx.organization.name,
+        name: ctx.instance.name,
+        state: ctx.instance.state,
+        podStatus: await instanceModel.getPodStatus(req.context)
+      });
     }
   }
 

--- a/services/lib/context.js
+++ b/services/lib/context.js
@@ -60,6 +60,7 @@ class InstanceDatabaseContext {
     this._database = null;
     this._instance = null;
     this._requestor = null;
+    this.requestorRoles = null;
 
     this.fullDatabaseName = null;
     this.logSignal = {};
@@ -183,6 +184,45 @@ class InstanceDatabaseContext {
       } else if( typeof obj.requestor === 'object' ) {
         this.requestor = obj.requestor.username;
       }
+    }
+
+    if( !this.requestorRoles ) {
+      this.requestorRoles = {};
+    }
+
+    if( this.instance && this.requestor ) {
+      try {
+        let instUser = await pgAdminClient.getInstanceUser(this, this.requestor);
+        this.requestorRoles.instance = instUser?.user_type || '';
+      } catch(e) {
+        this.requestorRoles.instance = '';
+      }
+    }
+
+    if( this.organization && this.requestor ) {
+      try {
+        let orgUser = await pgAdminClient.getOrganizationUser(this.requestor, this.organization.name);
+        this.requestorRoles.organization = orgUser?.user_type || '';
+      } catch(e) {
+        this.requestorRoles.organization = '';
+      }
+    }
+
+    // final cleanup of log signal
+    this.cleanLogSignal();
+  }
+
+  async populateRequestorRoles() {
+    if( !this.requestorRoles ) this.requestorRoles = {};
+
+    if( this.instance && this.requestor ) {
+      let instUser = await pgAdminClient.getInstanceUser(this, this.requestor);
+      this.requestorRoles.instance = instUser?.user_type || '';
+    }
+
+    if( this.organization && this.requestor ) {
+      let orgUser = await pgAdminClient.getOrganizationUser(this.requestor, this.organization.name);
+      this.requestorRoles.organization = orgUser?.user_type || '';
     }
 
     this.cleanLogSignal();

--- a/services/lib/keycloak.js
+++ b/services/lib/keycloak.js
@@ -371,15 +371,8 @@ class KeycloakUtils {
       return next();
     }
 
-    let organization = req.params.organization;
-
-    try {
-      let orgUser = await adminClient.getOrganizationUser(req.user.username, organization);
-      if( types.includes(orgUser?.user_type))  {
-        return next();
-      }
-    } catch(e) {
-      // todo; silence is golden?
+    if( types.includes(req.context?.requestorRoles?.organization) ) {
+      return next();
     }
 
     return res.status(403).send('Unauthorized');
@@ -392,14 +385,8 @@ class KeycloakUtils {
       return next();
     }
 
-    try {
-      let instUser = await adminClient.getInstanceUser(req.context, req.user.username);
-
-      if( types.includes(instUser?.user_type))  {
-        return next();
-      }
-    } catch(e) {
-      // todo; silence is golden?
+    if( types.includes(req.context?.requestorRoles?.instance) ) {
+      return next();
     }
 
     return res.status(403).send('Unauthorized');

--- a/services/lib/pg-admin-client.js
+++ b/services/lib/pg-admin-client.js
@@ -127,7 +127,7 @@ class PgFarmAdminClient {
 
   /**
    * @method getOrganizationUser
-   * @description get all users for an organization
+   * @description get a user for an organization
    *
    * @param {String} nameOrId organization name or ID
    * @returns {Promise<Array>}

--- a/services/models/admin.js
+++ b/services/models/admin.js
@@ -356,7 +356,7 @@ class AdminModel {
       let resources = await getInstanceResources(iCtx);
 
       if( resources.sleep ) {
-        logger.info('Instance has been idle for too long, shutting down', {podPriority: 0}, iCtx.logSignal);
+        logger.info('Instance has been idle for too long, shutting down', {podPriority: 0+""}, iCtx.logSignal);
         changed.push({instance, newState: 'SLEEP'});
         await this.stopInstance(iCtx);
         continue;
@@ -364,7 +364,7 @@ class AdminModel {
 
       let newPriority = parseInt(resources.name.split('-')[1]);
       if( newPriority !== instance.priority_state ) {
-        logger.info(`Instance priority has changed from ${instance.priority_state} to ${newPriority}, updating instance`, {podPriority: newPriority}, iCtx.logSignal);
+        logger.info(`Instance priority has changed from ${instance.priority_state} to ${newPriority}, updating instance`, {podPriority: newPriority+""}, iCtx.logSignal);
         await client.updateInstancePriority(iCtx, newPriority);
         await this.models.instance.apply(iCtx);
 
@@ -378,7 +378,7 @@ class AdminModel {
           }
         });
       } else if( newPriority ) {
-        logger.info(`Instance priority is still ${newPriority}, no change`, {podPriority: newPriority}, iCtx.logSignal);
+        logger.info(`Instance priority is still ${newPriority}, no change`, {podPriority: newPriority+""}, iCtx.logSignal);
       }
     }
 

--- a/services/models/admin.js
+++ b/services/models/admin.js
@@ -356,7 +356,7 @@ class AdminModel {
       let resources = await getInstanceResources(iCtx);
 
       if( resources.sleep ) {
-        logger.info('Instance has been idle for too long, shutting down', {podPriority: 0+""}, iCtx.logSignal);
+        logger.info('Instance has been idle for too long, shutting down', {podPriority: "0"}, iCtx.logSignal);
         changed.push({instance, newState: 'SLEEP'});
         await this.stopInstance(iCtx);
         continue;
@@ -364,7 +364,7 @@ class AdminModel {
 
       let newPriority = parseInt(resources.name.split('-')[1]);
       if( newPriority !== instance.priority_state ) {
-        logger.info(`Instance priority has changed from ${instance.priority_state} to ${newPriority}, updating instance`, {podPriority: newPriority+""}, iCtx.logSignal);
+        logger.info(`Instance priority has changed from ${instance.priority_state} to ${newPriority}, updating instance`, {podPriority: String(newPriority)}, iCtx.logSignal);
         await client.updateInstancePriority(iCtx, newPriority);
         await this.models.instance.apply(iCtx);
 
@@ -378,7 +378,7 @@ class AdminModel {
           }
         });
       } else if( newPriority ) {
-        logger.info(`Instance priority is still ${newPriority}, no change`, {podPriority: newPriority+""}, iCtx.logSignal);
+        logger.info(`Instance priority is still ${newPriority}, no change`, {podPriority: String(newPriority)}, iCtx.logSignal);
       }
     }
 

--- a/services/models/admin.js
+++ b/services/models/admin.js
@@ -168,20 +168,21 @@ class AdminModel {
    * @description Stops a running instance.  This will also stop all pgRest
    * services associated with the instance.
    *
-   * @param {String} ctx
+   * @param {String} iCtx instance context
    * @param {Object} opts
    * @param {Boolean} opts.isArchived set to true if the instance has been archived.  will set state to ARCHIVE
    *
    * @returns {Promise}
    */
-  async stopInstance(ctx, opts={}) {
-    await this.models.instance.stop(ctx, opts);
-    let dbs = await client.getInstanceDatabases(ctx);
+  async stopInstance(iCtx, opts={}) {
+    await this.models.instance.stop(iCtx, opts);
+    let dbs = await client.getInstanceDatabases(iCtx);
+    
+    // stop pgRest services
     for( let db of dbs ) {
-      await this.models.pgRest.stop({
-        database : {name: db.name},
-        organization : ctx.organization
-      });
+      let dbCtx = iCtx.clone();
+      await dbCtx.update({database: db.name});
+      await this.models.pgRest.stop(dbCtx);
     }
   }
 

--- a/services/models/instance.js
+++ b/services/models/instance.js
@@ -266,7 +266,7 @@ class Instance {
 
     // JM - perhaps we just add a now shutdown delay time after start.
     let maxPriority = await getMaxPriority(instance.availability);
-    logger.info('Database startup called, setting max pod priority', {podPriority: maxPriority+""}, ctx.logSignal);
+    logger.info('Database startup called, setting max pod priority', {podPriority: String(maxPriority)}, ctx.logSignal);
     await client.updateInstancePriority(ctx, maxPriority);
 
     let applyResp = await this.apply(ctx);
@@ -588,6 +588,12 @@ class Instance {
       stdin: true,
       isJson: true
     });
+  }
+
+  getPodStatus(ctx) {
+    ctx = getContext(ctx);
+    let podName = (ctx?.instance?.hostname)+'-0';
+    return kubectl.getPodStatus(podName);
   }
 
 }

--- a/services/models/instance.js
+++ b/services/models/instance.js
@@ -266,7 +266,7 @@ class Instance {
 
     // JM - perhaps we just add a now shutdown delay time after start.
     let maxPriority = await getMaxPriority(instance.availability);
-    logger.info('Database startup called, setting max pod priority', {podPriority: maxPriority}, ctx.logSignal);
+    logger.info('Database startup called, setting max pod priority', {podPriority: maxPriority+""}, ctx.logSignal);
     await client.updateInstancePriority(ctx, maxPriority);
 
     let applyResp = await this.apply(ctx);

--- a/services/models/pg-rest.js
+++ b/services/models/pg-rest.js
@@ -232,9 +232,6 @@ server-port = ${config.pgRest.port}`
 
     let database = ctx.database;
     let hostname = database.pgrest_hostname;
-
-    logger.info('Stopping PostgREST: '+hostname);
-
     let pgrestResult, pgrestServiceResult;
 
     try {
@@ -243,7 +240,7 @@ server-port = ${config.pgRest.port}`
       logger.warn('Error deleting statefulset', e.message);
       pgrestResult = {
         message : e.message,
-        stack : e.stacks
+        stack : e.stack
       }
     }
 
@@ -253,7 +250,7 @@ server-port = ${config.pgRest.port}`
       logger.warn('Error deleting service', e.message);
       pgrestServiceResult = {
         message : e.message,
-        stack : e.stacks
+        stack : e.stack
       }
     }
 

--- a/tools/cli/lib/print.js
+++ b/tools/cli/lib/print.js
@@ -173,8 +173,12 @@ class Print {
 
   instance(i) {
     console.log(`${i.name}:`);
-    console.log(`  - Organization: ${i.organization_name}`);
-    console.log(`  - Databases: ${(i.databases || []).join(', ')}`);
+    if( i.organization ) {
+      console.log(`  - Organization: ${i.organization.name}`);
+    }
+    if( i.databases ) {
+      console.log(`  - Database(s): ${(i.databases || []).map(d => d.name).join(', ')}`);
+    }
     console.log(`  - State: ${i.state}`);
   }
 


### PR DESCRIPTION
Would return 503 when an instance is not able to be reached.  JSON payload would explain.  Additionally we could look to add error code to json payload as well as retry header. 

This would allow clients to better understand the failed request and retry after a 5/10 second delay.

This does not handle the PG Rest use case.