### PR TITLE
Jm active disconnect

### DIFF
--- a/services/administration/k8s/pgrest/base/deployment.yaml
+++ b/services/administration/k8s/pgrest/base/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         - name: PGREST_ORGANIZATION_NAME
           value: 
         resources:
+          requests:
+            memory: "250Mi"
+            cpu: "0.25"
           limits:
             memory: "500Mi"
             cpu: "1"

--- a/services/administration/src/controllers/api/instance.js
+++ b/services/administration/src/controllers/api/instance.js
@@ -77,7 +77,7 @@ router.post('/',
   }
 });
 
-router.put('/:organization/:instance/:user',
+router.put('/:organization/:instance/user/:user',
   contextMiddleware,
   keycloak.protect('instance-admin'),
   isInstanceAlive(),
@@ -100,7 +100,7 @@ router.put('/:organization/:instance/:user',
   }
 });
 
-router.patch('/:organization/:instance/:user',
+router.patch('/:organization/:instance/user/:user',
   contextMiddleware,
   keycloak.protect('instance-admin'),
   async (req, res) => {
@@ -121,7 +121,7 @@ router.patch('/:organization/:instance/:user',
   }
 });
 
-router.delete('/:organization/:instance/:user',
+router.delete('/:organization/:instance/user/:user',
   contextMiddleware,
   keycloak.protect('instance-admin'),
   isInstanceAlive(),
@@ -178,6 +178,18 @@ router.post('/:organization/:instance/restart',
   async (req, res) => {
   try {
     let resp = await instanceModel.restart(req.context);
+    res.status(200).json(resp);
+  } catch(e) {
+    handleError(res, e);
+  }
+});
+
+router.patch('/:organization/:instance/priority/:priority',
+  contextMiddleware,
+  keycloak.protect('admin'),
+  async (req, res) => {
+  try {
+    let resp = await instanceModel.updatePriority(req.context, req.params.priority, req.query.apply === 'true');
     res.status(200).json(resp);
   } catch(e) {
     handleError(res, e);

--- a/tools/cli/bin/pgfarm-instance.js
+++ b/tools/cli/bin/pgfarm-instance.js
@@ -96,6 +96,12 @@ program.command('resize <org/instance> <size>')
     instance.resize(instanceName, size);
   });
 
+program.command('priority <org/instance> <priority>')
+  .description('Increase priority of postgres instance '+print.pgFarmAdminOnlyMsg())
+  .option('-a, --apply', 'Apply the priority change to k8s (recommended)')
+  .action((instanceName, priority, opts) => {
+    instance.updatePriority(instanceName, priority, opts);
+  });
 
 program.command('sync-users <org/instance>')
   .description('Sync postgres instance users '+print.pgFarmAdminOnlyMsg())

--- a/tools/cli/lib/instance.js
+++ b/tools/cli/lib/instance.js
@@ -108,6 +108,13 @@ class Instances {
     process.exit(0);
   }
 
+  async updatePriority(name, priority, opts) {
+    let { organization, instance } = this.parseOrg(name);
+    let resp = await instanceModel.updatePriority(organization, instance, priority, opts.apply);
+
+    print.display(resp, opts.output);
+    process.exit(0);
+  }
 
   async backup(instance) {
     instance = formatInstName(instance);

--- a/tools/lib/models/InstanceModel.js
+++ b/tools/lib/models/InstanceModel.js
@@ -79,6 +79,11 @@ class InstanceModel extends BaseModel {
     return this.service.restart(org, instance);
   }
 
+  updatePriority(org, instance, priority, apply=false) {
+    instance = this.formatName(instance);
+    return this.service.updatePriority(org, instance, priority, apply);
+  }
+
   backup(org, instance) {
     instance = this.formatName(instance);
     return this.service.backup(org, instance);

--- a/tools/lib/services/InstanceService.js
+++ b/tools/lib/services/InstanceService.js
@@ -82,7 +82,7 @@ class InstanceService extends BaseService {
     if( opts.parent ) flags.parent = opts.parent;
 
     await this.request({
-      url: `${this.basePath}/${org}/${instance}/${user}`,
+      url: `${this.basePath}/${org}/${instance}/user/${user}`,
       qs: flags,
       fetchOptions: {
         method : 'PUT',
@@ -105,7 +105,7 @@ class InstanceService extends BaseService {
     };
 
     await this.request({
-      url: `${this.basePath}/${org}/${instance}/${user}`,
+      url: `${this.basePath}/${org}/${instance}/user/${user}`,
       qs: flags,
       fetchOptions: {
         method : 'PATCH',
@@ -125,7 +125,7 @@ class InstanceService extends BaseService {
     let id = payload.getKey(ido);
 
     await this.request({
-      url: `${this.basePath}/${org}/${instance}/${user}`,
+      url: `${this.basePath}/${org}/${instance}/user/${user}`,
       fetchOptions: {
         method : 'DELETE',
         headers: serviceUtils.authHeader()
@@ -196,6 +196,28 @@ class InstanceService extends BaseService {
     });
 
     return this.store.data.restart.get(id);
+  }
+
+  async updatePriority(org, instance, priority, apply=false) {
+    let id = payload.getKey({org, instance});
+
+    let opts = {};
+    if( apply ) opts.apply = true;
+
+    await this.request({
+      url: `${this.basePath}/${org}/${instance}/priority/${priority}`,
+      fetchOptions: {
+        method : 'PATCH',
+        headers: serviceUtils.authHeader()
+      },
+      qs: opts,
+      json: true,
+      onLoading: request => this.store.onPriorityUpdate({org, instance}, {request}),
+      onLoad: payload => this.store.onPriorityUpdate({org, instance}, {payload: payload.body}),
+      onError: error => this.store.onPriorityUpdate({org, instance}, {error})
+    });
+
+    return this.store.data.priority.get(id);
   }
 
   async backup(org, instance) {

--- a/tools/lib/stores/InstanceStore.js
+++ b/tools/lib/stores/InstanceStore.js
@@ -14,6 +14,7 @@ class InstanceStore extends BaseStore {
       start : new LruStore({name: 'instance.start'}),
       stop : new LruStore({name: 'instance.stop'}),
       restart : new LruStore({name: 'instance.restart'}),
+      priority : new LruStore({name: 'instance.priority'}),
       backup : new LruStore({name: 'instance.backup'}),
       archive : new LruStore({name: 'instance.archive'}),
       restore : new LruStore({name: 'instance.restore'}),
@@ -36,6 +37,7 @@ class InstanceStore extends BaseStore {
       INSTANCE_ARCHIVE_UPDATE : 'instance-archive-update',
       INSTANCE_RESTORE_UPDATE : 'instance-restore-update',
       INSTANCE_RESIZE_UPDATE : 'instance-resize-update',
+      INSTANCE_PRIORITY_UPDATE : 'instance-priority-update',
       INSTANCE_SYNC_USERS_UPDATE : 'instance-sync-users-update',
     };
   }
@@ -109,6 +111,14 @@ class InstanceStore extends BaseStore {
       payloadUtils.generate(ido, payload),
       this.data.restart,
       this.events.INSTANCE_RESTART_UPDATE
+    );
+  }
+
+  onPriorityUpdate(ido, payload) {
+    this._set(
+      payloadUtils.generate(ido, payload),
+      this.data.priority,
+      this.events.INSTANCE_PRIORITY_UPDATE
     );
   }
 


### PR DESCRIPTION
This PR keeps track of active connections and kills them if the connection was 'working' during server disconnect event.  This ensures the client is aware of any transactional failure do to k8s or pg farm operation.